### PR TITLE
added EnvYAML.__init__ kwargs support to allow override of envvars

### DIFF
--- a/envyaml/envyaml.py
+++ b/envyaml/envyaml.py
@@ -66,7 +66,8 @@ class EnvYAML:
     __strict = True  # type: bool
 
     def __init__(
-        self, yaml_file=None, env_file=None, include_environment=True, strict=True
+        self, yaml_file=None, env_file=None, include_environment=True, strict=True,
+        **kwargs
     ):
         """Create EnvYAML class instance and read content from environment and files if they exists
 
@@ -74,6 +75,7 @@ class EnvYAML:
         :param str env_file: file path for .env file or None by default
         :param bool include_environment: include environment variable, by default true
         :param bool strict: use strict mode and throw exception when have unset variable, by default true
+        :param dict kwargs: additional environment variables keys and values
         :return: new instance of EnvYAML
         """
         # raise exception module not found when no pyyaml installed
@@ -99,6 +101,11 @@ class EnvYAML:
                 self.__get_file_path(env_file, "ENV_FILE", self.DEFAULT_ENV_FILE),
                 self.__strict,
             )
+        )
+
+        # fill cfg with kwargs
+        self.__cfg.update(
+            kwargs
         )
 
         # read yaml file and parse it

--- a/tests/test_envyaml.py
+++ b/tests/test_envyaml.py
@@ -358,3 +358,12 @@ def test_it_should_properly_resolve_extra_fields():
     env = EnvYAML("tests/env.default.yaml", "tests/test.env")
 
     assert env["extra.password_extra_1"] == "password-extra"
+
+
+def test_it_should_override_cfg_with_kwargs():
+    d = dict(PROJECT_NAME="project-x-UPDATED")
+    env = EnvYAML("tests/env.default.yaml",
+                  "tests/test.env",
+                  **d)
+
+    assert env["PROJECT_NAME"] == "project-x-UPDATED"


### PR DESCRIPTION
Notice the following `.env` snippet from the popular [python-dotenv](https://github.com/theskumar/python-dotenv) package:
```yaml
DOMAIN=example.org
ADMIN_EMAIL=admin@${DOMAIN}
ADMIN_PASSWORD=super_secret_password
ROOT_URL=${DOMAIN}/app
```

If we load this `.env` using the current `envyaml` we'll get:
```python
dict(
  DOMAIN="example.org",
  ADMIN_EMAIL="admin@${DOMAIN}",
  ADMIN_PASSWORD="super_secret_password",
  ROOT_URL="${DOMAIN}/app"
)
```

I suggest fixing this by adding a `kwargs` as I did on the `EnvYAML.__init__` ctor.

This will allow the following code:
```python
def envyaml_with_dotenv_demo():
    from envyaml import EnvYAML

    dotenv_path = Path('.') / '.env'

    # read file env.yaml and parse config
    env_yaml_path = Path('.') / 'env.yaml'
    env = EnvYAML(env_yaml_path,
                  env_file=dotenv_path,
                  # don't fail if some env var is missing
                  strict=False,
                  **dotenv.dotenv_values(dotenv_path)
                  )
```
I also added a dedicated test: `test_it_should_override_cfg_with_kwargs`.

I just noticed I forgot to update the `setup.py`::`install_requires` with `python-dotenv`.