### PR TITLE
added EnvYAML(flatten:bool) flag so that flattening can be controlled

### DIFF
--- a/envyaml/envyaml.py
+++ b/envyaml/envyaml.py
@@ -72,6 +72,7 @@ class EnvYAML:
         env_file=None,
         include_environment=True,
         strict=True,
+        flatten=True,
         **kwargs
     ):
         """Create EnvYAML class instance and read content from environment and files if they exists
@@ -80,6 +81,7 @@ class EnvYAML:
         :param str env_file: file path for .env file or None by default
         :param bool include_environment: include environment variable, by default true
         :param bool strict: use strict mode and throw exception when have unset variable, by default true
+        :param bool flatten: whether we should flatten config hierarchy or not
         :param dict kwargs: additional environment variables keys and values
         :return: new instance of EnvYAML
         """
@@ -127,7 +129,8 @@ class EnvYAML:
             self.__cfg.update(yaml_config)
 
         # make config as flat dict with '.'
-        self.__cfg = self.__flat(self.__cfg)
+        if flatten:
+            self.__cfg = self.__flat(self.__cfg)
 
     def get(self, key, default=None):
         """Get configuration variable with default value. If no `default` value set use None

--- a/tests/test_envyaml.py
+++ b/tests/test_envyaml.py
@@ -3,7 +3,6 @@ from __future__ import absolute_import, unicode_literals
 
 import os
 import sys
-
 import pytest
 
 from envyaml import EnvYAML
@@ -364,3 +363,13 @@ def test_it_should_override_cfg_with_kwargs():
     env = EnvYAML("tests/env.default.yaml", "tests/test.env", **d)
 
     assert env["PROJECT_NAME"] == "project-x-UPDATED"
+
+
+def test_it_should_not_flatten():
+    env = EnvYAML(
+        yaml_file="tests/env.default.yaml", env_file="tests/test.env", strict=True,
+        flatten=False
+    )
+
+    assert env["config"]["with_default"] == "DEFAULT"
+    assert "config.with_default" not in env


### PR DESCRIPTION
When using EnvYAML, it could be great if we can decide whether to `flatten` the config hierarchy or not.
When flatten=False, we can update the loaded EnvYAML instance only in one place (using the dictionary [] convention) and not twice (the flatten copied `.` keys also).
I added a unit test also. Version should be bumped.