### PR TITLE
Do specific replacement instead of a general replace for escaped dollar signs

### DIFF
--- a/envyaml/envyaml.py
+++ b/envyaml/envyaml.py
@@ -51,7 +51,7 @@ RE_PATTERN = re.compile(
     re.MULTILINE | re.UNICODE | re.IGNORECASE | re.VERBOSE,
 )
 
-__version__ = "1.9.210927"
+__version__ = "1.10.211227"
 
 
 class EnvYAML:

--- a/envyaml/envyaml.py
+++ b/envyaml/envyaml.py
@@ -217,6 +217,8 @@ class EnvYAML:
         # changes dictionary
         replaces = dict()
 
+        shifting = 0
+
         # iterate over findings
         for entry in RE_PATTERN.finditer(content):
             groups = entry.groupdict()  # type: dict
@@ -235,7 +237,11 @@ class EnvYAML:
                 default = groups["braced_default"]
 
             elif groups["escaped"] and "$" in groups["escaped"]:
-                content = content.replace("$" + groups["escaped"], groups["escaped"])
+                span = entry.span()
+                content = content[:span[0] + shifting] + groups["escaped"] + content[span[1] + shifting:]
+                # Added shifting since every time we update content we are
+                # changing the original groups spans
+                shifting += len(groups["escaped"]) - (span[1] - span[0])
 
             if variable is not None:
                 if variable in cfg:

--- a/tests/env.default.yaml
+++ b/tests/env.default.yaml
@@ -28,5 +28,8 @@ test_escape:
   three: $${bracket}
   four: SomePa$$$$$$word
   five: SomePa$$$$$${word}
+  six: $$$PASSWORD
+  seven: $$${PASSWORD}
+  eight: $$${NON_EXISTING|DEFAULT}
 
 key_with_slash: $ENV_WITH_SLASH

--- a/tests/env.default.yaml
+++ b/tests/env.default.yaml
@@ -26,5 +26,7 @@ test_escape:
   one: $$.foo
   two: $$meet
   three: $${bracket}
+  four: SomePa$$$$$$word
+  five: SomePa$$$$$${word}
 
 key_with_slash: $ENV_WITH_SLASH

--- a/tests/test_envyaml.py
+++ b/tests/test_envyaml.py
@@ -349,6 +349,8 @@ def test_it_should_pass_escaped_variable():
     assert env["test_escape.one"] == "$.foo"
     assert env["test_escape.two"] == "$meet"
     assert env["test_escape.three"] == "${bracket}"
+    assert env["test_escape.four"] == "SomePa$$$word"
+    assert env["test_escape.five"] == "SomePa$$${word}"
 
 
 def test_it_should_properly_resolve_extra_fields():

--- a/tests/test_envyaml.py
+++ b/tests/test_envyaml.py
@@ -351,6 +351,9 @@ def test_it_should_pass_escaped_variable():
     assert env["test_escape.three"] == "${bracket}"
     assert env["test_escape.four"] == "SomePa$$$word"
     assert env["test_escape.five"] == "SomePa$$${word}"
+    assert env["test_escape.six"] == "$env-password-with-escape"
+    assert env["test_escape.seven"] == "$env-password-with-escape"
+    assert env["test_escape.eight"] == "$DEFAULT"
 
 
 def test_it_should_properly_resolve_extra_fields():


### PR DESCRIPTION
This is a solution proposal for #31 

Instead of doing a general `content.replace` to replace escaped characters we should remove the specific span and replace.

This PR is the implementation for this proposal.