### PR TITLE
Fix support for case-insensitive environment variables on Windows

### DIFF
--- a/envyaml/envyaml.py
+++ b/envyaml/envyaml.py
@@ -24,6 +24,7 @@
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 # SOFTWARE.
 
+import collections
 import io
 import os
 import re
@@ -93,7 +94,7 @@ class EnvYAML:
             )
 
         # read environment
-        self.__cfg = dict(os.environ) if include_environment else {}
+        self.__cfg = collections.ChainMap({}, os.environ) if include_environment else {}
 
         # set strict mode to false if "ENVYAML_STRICT_DISABLE" presents in env else use "strict" from function
         self.__strict = False if self.ENVYAML_STRICT_DISABLE in self.__cfg else strict

--- a/tests/env.test.yaml
+++ b/tests/env.test.yaml
@@ -83,6 +83,8 @@ var_in_array:
 var_in_dict:
   extra: { user: $USERNAME, password: $PASSWORD }
 
+mixed_case_var_name: ${mixed_CASE|fail}
+
 #
 # Comments
 #

--- a/tests/test_envyaml.py
+++ b/tests/test_envyaml.py
@@ -403,3 +403,10 @@ def test_it_should_not_flatten():
 
     assert env["config"]["with_default"] == "DEFAULT"
     assert "config.with_default" not in env
+
+
+def test_it_should_access_mixed_case_environment_variables():
+    os.environ["mixed_CASE"] = "pass"
+    env = EnvYAML("tests/env.test.yaml", env_file="tests/test.env")
+    assert env["mixed_case_var_name"] == "pass"
+    del os.environ["mixed_CASE"]


### PR DESCRIPTION
Ensure variable lookups hit `os.environ` itself, rather than a dict copy

Fixes #47